### PR TITLE
handle multiple replacements

### DIFF
--- a/index.js
+++ b/index.js
@@ -7,16 +7,11 @@
  */
 function replaceArguments(command, args) {
 	const regex = /\$(\d+)/g;
-	const numbers = [];
 	let match;
 
 	while ((match = regex.exec(command)) !== null) {
-		numbers.push(match[1]);
-	}
-
-	if (numbers.length > 0) {
-		const number1 = numbers[0];
-		return command.replace(`$${number1}`, args[parseInt(number1) - 1]);
+		const index = match[1]
+		command = command.replaceAll(`$${index}`, args[parseInt(index) - 1]);
 	}
 
 	return command;

--- a/index.js
+++ b/index.js
@@ -11,7 +11,7 @@ function replaceArguments(command, args) {
 
 	while ((match = regex.exec(command)) !== null) {
 		const index = match[1]
-		command = command.replaceAll(`$${index}`, args[parseInt(index) - 1]);
+		command = command.replace(`$${index}`, args[parseInt(index) - 1]);
 	}
 
 	return command;


### PR DESCRIPTION
I've refactored the core code to handle the following cases:

1. A positional argument is used multiple times:
```
echo $1 $1 $1
```

2. Several arguments are used:
```
echo $1 $2 $3
```